### PR TITLE
Supporting proxy option pass to oauth gem

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -106,8 +106,8 @@ module JIRA
       if options[:use_client_cert]
         raise ArgumentError, 'Options: :cert_path must be set when :use_client_cert is true' unless @options[:cert_path]
         raise ArgumentError, 'Options: :key_path must be set when :use_client_cert is true' unless @options[:key_path]
-        @options[:cert] = OpenSSL::X509::Certificate.new(File.read(@options[:cert_path]))
-        @options[:key] = OpenSSL::PKey::RSA.new(File.read(@options[:key_path]))
+        @options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(@options[:cert_path]))
+        @options[:ssl_client_key] = OpenSSL::PKey::RSA.new(File.read(@options[:key_path]))
       end
 
       case options[:auth_type]

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -46,6 +46,8 @@ module JIRA
 
     def http_conn(uri)
       if @options[:proxy_address]
+        # proxy_address does not exist in oauth's gem context but proxy does
+        @options[:proxy] = @options[:proxy_address]
         http_class = Net::HTTP::Proxy(@options[:proxy_address], @options[:proxy_port] || 80, @options[:proxy_username], @options[:proxy_password])
       else
         http_class = Net::HTTP
@@ -53,8 +55,8 @@ module JIRA
       http_conn = http_class.new(uri.host, uri.port)
       http_conn.use_ssl = @options[:use_ssl]
       if @options[:use_client_cert]
-        http_conn.cert = @options[:cert]
-        http_conn.key = @options[:key]
+        http_conn.cert = @options[:ssl_client_cert]
+        http_conn.key = @options[:ssl_client_key]
       end
       http_conn.verify_mode = @options[:ssl_verify_mode]
       http_conn.ssl_version = @options[:ssl_version] if @options[:ssl_version]

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -280,8 +280,8 @@ describe JIRA::HttpClient do
     expect(http_conn).to receive(:use_ssl=).with(basic_client.options[:use_ssl])
     expect(http_conn).to receive(:verify_mode=).with(basic_client.options[:ssl_verify_mode])
     expect(http_conn).to receive(:read_timeout=).with(basic_client.options[:read_timeout])
-    expect(http_conn).to receive(:cert=).with(basic_client_cert_client.options[:cert])
-    expect(http_conn).to receive(:key=).with(basic_client_cert_client.options[:key])
+    expect(http_conn).to receive(:cert=).with(basic_client_cert_client.options[:ssl_client_cert])
+    expect(http_conn).to receive(:key=).with(basic_client_cert_client.options[:ssl_client_key])
     expect(basic_client_cert_client.http_conn(uri)).to eq(http_conn)
   end
 


### PR DESCRIPTION
Fix For following scenario:

When trying to authenticate using a local instance of Jira through **Oauth** gem, the `proxy` option is needed in the **Consumer.rb**, but currently the option is rejected on the Client.rb class or `jira-ruby`.

This pr will create the `proxy` option when detecting the existence of `proxy_address` supporting both gems at the same time.

Also adding `ssl_client` as a suffix to options `cert` and `key`.

Oauth gem > Consumer.rb

![Screen Shot 2020-07-09 at 11 55 14 AM](https://user-images.githubusercontent.com/63871119/87073713-1571ce80-c1db-11ea-8351-a6f0f29ace00.png)
![Screen Shot 2020-07-09 at 11 54 51 AM](https://user-images.githubusercontent.com/63871119/87073750-202c6380-c1db-11ea-94eb-506799908135.png)

